### PR TITLE
feat: add Groq LLM provider support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+## Project Overview
+
+Monorepo with React/Vite frontend and FastAPI backend. Natural language real estate search using Ollama LLM + MySQL.
+
+## Run Commands
+
+```bash
+# Start all services (from root)
+docker compose -f docker-compose.dev.yml up --build
+
+# Frontend only (if not using Docker)
+cd frontend && npm install && npm run dev
+
+# Frontend lint/typecheck (after npm install)
+cd frontend && npm run lint
+cd frontend && npm run typecheck
+
+# Rebuild after schema changes
+docker compose -f docker-compose.dev.yml down -v && docker compose -f docker-compose.dev.yml up --build
+```
+
+## Service URLs
+
+| Service | URL |
+|---------|-----|
+| Frontend | http://localhost:5173 |
+| Backend | http://localhost:8000 |
+| API Docs | http://localhost:8000/docs |
+| MySQL | localhost:3306 |
+| Adminer | http://localhost:8080 |
+
+## Architecture
+
+```
+API (routers/) → Services (services/) → Repositories (repositories/) → Database
+```
+
+Entry point: `backend/app/main.py`
+
+## Key Constraints
+
+- **Ollama runs on host**, not in Docker. Must have `ollama serve` running on machine before starting containers.
+- Backend uses `extra_hosts` to reach host's Ollama from inside container.
+- Recreate MySQL volume (`-v` flag) when schema or seed data changes.
+- Python uses UV package manager (see `backend/pyproject.toml`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,19 +6,25 @@ Monorepo with React/Vite frontend and FastAPI backend. Natural language real est
 
 ## Run Commands
 
+Makefile available for convenience:
+
 ```bash
-# Start all services (from root)
-docker compose -f docker-compose.dev.yml up --build
+# All services (Docker)
+make dev
 
-# Frontend only (if not using Docker)
-cd frontend && npm install && npm run dev
+# Frontend only
+make frontend-install
+make frontend-dev
 
-# Frontend lint/typecheck (after npm install)
-cd frontend && npm run lint
-cd frontend && npm run typecheck
+# Frontend lint/typecheck
+make frontend-lint
+make frontend-typecheck
 
 # Rebuild after schema changes
-docker compose -f docker-compose.dev.yml down -v && docker compose -f docker-compose.dev.yml up --build
+make dev-rebuild
+
+# Or manually:
+cd frontend && npm install && npm run dev
 ```
 
 ## Service URLs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+# Dev commands
+dev:
+	docker compose -f docker-compose.dev.yml up --build
+
+dev-down:
+	docker compose -f docker-compose.dev.yml down
+
+dev-rebuild:
+	docker compose -f docker-compose.dev.yml down -v
+	docker compose -f docker-compose.dev.yml up --build
+
+# Frontend only
+frontend-install:
+	cd frontend && npm install
+
+frontend-dev:
+	cd frontend && npm run dev
+
+frontend-lint:
+	cd frontend && npm run lint
+
+frontend-typecheck:
+	cd frontend && npm run typecheck
+
+frontend-build:
+	cd frontend && npm run build
+
+# Backend only
+backend-install:
+	cd backend && uv sync
+
+backend-dev:
+	cd backend && uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+
+# Help
+help:
+	@echo "Available commands:"
+	@echo "  make dev              - Start all services with Docker"
+	@echo "  make dev-down        - Stop all services"
+	@echo "  make dev-rebuild     - Rebuild after schema changes"
+	@echo "  make frontend-dev  - Run frontend only (requires backend running)"
+	@echo "  make frontend-lint - Lint frontend"
+	@echo "  make help          - Show this help"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,11 @@
+# Database
+DATABASE_URL=mysql+pymysql://user:password@db:3306/db
+
+# Ollama (local)
+OLLAMA_API=http://host.docker.internal:11434
+
+# Groq (cloud - get free key at https://console.groq.com)
+GROQ_API_KEY=
+
+# LLM provider: "ollama" or "groq"
+LLM_PROVIDER=ollama

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -4,6 +4,8 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     database_url: str = ""
     ollama_api: str = ""
+    groq_api_key: str = ""
+    llm_provider: str = "ollama"  # "ollama" or "groq"
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf8")
 

--- a/backend/app/core/startup_checks.py
+++ b/backend/app/core/startup_checks.py
@@ -11,6 +11,9 @@ def check_database():
 
 
 def check_ollama():
+    if settings.llm_provider != "ollama":
+        print("Using Groq provider, skipping Ollama check")
+        return
     response = requests.get(f"{settings.ollama_api}/api/tags", timeout=5)
     response.raise_for_status()
     print("Ollama connected successfully")

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,0 +1,1 @@
+# Services module

--- a/backend/app/services/groq_service.py
+++ b/backend/app/services/groq_service.py
@@ -1,73 +1,17 @@
 import json
 import os
 from groq import Groq
-from app.utils.user_query import normalize_user_query
+from app.services.prompts import build_prompt
+from app.core.config import settings
 
 MODEL_NAME = "llama-3.1-70b-versatile"
 
 DATABASE_ENGINE = "MYSQL"
 
-SYSTEM_PROMPT = """
-You are an expert MySQL SQL generator.
-
-Your task is to convert natural language into a SAFE SQL query.
-
-DATABASE:
-Table: real_estates
-
-Allowed columns:
-id, title, description, type, price, rooms, restroom, area_m2, location, published_date
-
-Use ONLY the exact database column names in English:
-id, title, description, type, price, rooms, restroom, area_m2, location, published_date
-
-IMPORTANT VALUE MAPPING:
-- The database values are in SPANISH.
-- Always use SPANISH values for the type column.
-- apartment / apartamento = departamento
-- house / casa = casa
-- land / terreno = terreno
-
-
-RULES FOR TEXT SEARCH:
-- For location  ALWAYS use LIKE with wildcards
-- Example: location LIKE '%Zona 14%'
-- Never use exact match for location
-- For rooms, and restroom ALWAYS use INT values NO boolean
-
-
-STRICT RULES:
-1. ONLY generate one SELECT statement
-2. NEVR generate INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE
-3. NEVER include markdown
-4. NEVER include explanations
-5. NEVER include comments
-6. NEVER include text before or after the SQL
-7. Response MUST start with SELECT
-8. Response MUST end with semicolon
-
-STRICT OUTPUT RULES:
-- DO NOT use markdown
-- DO NOT use ```sql
-- RETURN plain text only
-- START directly with SELECT
-"""
-
-
-def build_prompt(natural_query: str) -> str:
-    prompt = f"""
-    {SYSTEM_PROMPT}
-
-    USER REQUEST:
-    {natural_query}
-    """
-
-    return prompt
-
 
 def generate_sql(natural_query: str) -> str:
     client = Groq(
-        api_key=os.environ.get("GROQ_API_KEY", ""),
+        api_key=settings.groq_api_key,
     )
 
     prompt = build_prompt(natural_query)

--- a/backend/app/services/groq_service.py
+++ b/backend/app/services/groq_service.py
@@ -1,0 +1,95 @@
+import json
+import os
+from groq import Groq
+from app.utils.user_query import normalize_user_query
+
+MODEL_NAME = "llama-3.1-70b-versatile"
+
+DATABASE_ENGINE = "MYSQL"
+
+SYSTEM_PROMPT = """
+You are an expert MySQL SQL generator.
+
+Your task is to convert natural language into a SAFE SQL query.
+
+DATABASE:
+Table: real_estates
+
+Allowed columns:
+id, title, description, type, price, rooms, restroom, area_m2, location, published_date
+
+Use ONLY the exact database column names in English:
+id, title, description, type, price, rooms, restroom, area_m2, location, published_date
+
+IMPORTANT VALUE MAPPING:
+- The database values are in SPANISH.
+- Always use SPANISH values for the type column.
+- apartment / apartamento = departamento
+- house / casa = casa
+- land / terreno = terreno
+
+
+RULES FOR TEXT SEARCH:
+- For location  ALWAYS use LIKE with wildcards
+- Example: location LIKE '%Zona 14%'
+- Never use exact match for location
+- For rooms, and restroom ALWAYS use INT values NO boolean
+
+
+STRICT RULES:
+1. ONLY generate one SELECT statement
+2. NEVR generate INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE
+3. NEVER include markdown
+4. NEVER include explanations
+5. NEVER include comments
+6. NEVER include text before or after the SQL
+7. Response MUST start with SELECT
+8. Response MUST end with semicolon
+
+STRICT OUTPUT RULES:
+- DO NOT use markdown
+- DO NOT use ```sql
+- RETURN plain text only
+- START directly with SELECT
+"""
+
+
+def build_prompt(natural_query: str) -> str:
+    prompt = f"""
+    {SYSTEM_PROMPT}
+
+    USER REQUEST:
+    {natural_query}
+    """
+
+    return prompt
+
+
+def generate_sql(natural_query: str) -> str:
+    client = Groq(
+        api_key=os.environ.get("GROQ_API_KEY", ""),
+    )
+
+    prompt = build_prompt(natural_query)
+
+    response = client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=[
+            {
+                "role": "user",
+                "content": prompt,
+            }
+        ],
+        temperature=0,
+        response_format={
+            "type": "json_object",
+            "properties": {"sql": {"type": "string"}},
+            "required": ["sql"],
+        },
+    )
+
+    result = response.choices[0].message.content
+
+    sql = json.loads(result)["sql"]
+
+    return sql

--- a/backend/app/services/ollama_service.py
+++ b/backend/app/services/ollama_service.py
@@ -1,68 +1,11 @@
 import json
 import requests
 from app.core.config import settings
-from app.utils.user_query import normalize_user_query
+from app.services.prompts import build_prompt
 
 MODEL_NAME = "phi3"
 
 DATABASE_ENGINE = "MYSQL"
-
-SYSTEM_PROMPT = """
-You are an expert MySQL SQL generator.
-
-Your task is to convert natural language into a SAFE SQL query.
-
-DATABASE:
-Table: real_estates
-
-Allowed columns:
-id, title, description, type, price, rooms, restroom, area_m2, location, published_date
-
-Use ONLY the exact database column names in English:
-id, title, description, type, price, rooms, restroom, area_m2, location, published_date
-
-IMPORTANT VALUE MAPPING:
-- The database values are in SPANISH.
-- Always use SPANISH values for the type column.
-- apartment / apartamento = departamento
-- house / casa = casa
-- land / terreno = terreno
-
-
-RULES FOR TEXT SEARCH:
-- For location  ALWAYS use LIKE with wildcards
-- Example: location LIKE '%Zona 14%'
-- Never use exact match for location
-- For rooms, and restroom ALWAYS use INT values NO boolean
-
-
-STRICT RULES:
-1. ONLY generate one SELECT statement
-2. NEVER generate INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE
-3. NEVER include markdown
-4. NEVER include explanations
-5. NEVER include comments
-6. NEVER include text before or after the SQL
-7. Response MUST start with SELECT
-8. Response MUST end with semicolon
-
-STRICT OUTPUT RULES:
-- DO NOT use markdown
-- DO NOT use ```sql
-- RETURN plain text only
-- START directly with SELECT
-"""
-
-
-def build_prompt(natural_query: str) -> str:
-    prompt = f"""
-    {SYSTEM_PROMPT}
-
-    USER REQUEST:
-    {natural_query}
-    """
-
-    return prompt
 
 
 def generate_sql(natural_query: str) -> str:

--- a/backend/app/services/prompts.py
+++ b/backend/app/services/prompts.py
@@ -1,0 +1,69 @@
+# Shared prompts for LLM services
+
+SYSTEM_PROMPT = """
+You are an expert MySQL SQL generator.
+
+Your task is to convert natural language into a SAFE SQL query.
+
+DATABASE:
+Table: real_estates
+
+Allowed columns:
+id, title, description, type, price, rooms, restroom, area_m2, location, published_date
+
+Use ONLY the exact database column names in English:
+id, title, description, type, price, rooms, restroom, area_m2, location, published_date
+
+IMPORTANT VALUE MAPPING:
+- The database values are in SPANISH.
+- Always use SPANISH values for the type column.
+- apartment / apartamento = departamento
+- house / casa = casa
+- land / terreno = terreno
+
+
+RULES FOR TEXT SEARCH:
+- For location  ALWAYS use LIKE with wildcards
+- Example: location LIKE '%Zona 14%'
+- Never use exact match for location
+- For rooms, and restroom ALWAYS use INT values NO boolean
+
+
+STRICT RULES:
+1. ONLY generate one SELECT statement
+2. NEVER generate INSERT, UPDATE, DELETE, DROP, ALTER, TRUNCATE
+3. NEVER include markdown
+4. NEVER include explanations
+5. NEVER include comments
+6. NEVER include text before or after the SQL
+7. Response MUST start with SELECT
+8. Response MUST end with semicolon
+
+STRICT OUTPUT RULES:
+- DO NOT use markdown
+- DO NOT use ```sql
+- RETURN plain text only
+- START directly with SELECT
+"""
+
+ALLOWED_COLUMNS = [
+    "id",
+    "title",
+    "description",
+    "type",
+    "price",
+    "rooms",
+    "restroom",
+    "area_m2",
+    "location",
+    "published_date",
+]
+
+
+def build_prompt(natural_query: str) -> str:
+    return f"""
+    {SYSTEM_PROMPT}
+
+    USER REQUEST:
+    {natural_query}
+    """

--- a/backend/app/services/real_estate_service.py
+++ b/backend/app/services/real_estate_service.py
@@ -1,6 +1,13 @@
 from app.repositories.real_estate_repository import RealStateRepository
-from app.services.ollama_service import generate_sql
+from app.core.config import settings
+from app.services import ollama_service, groq_service
 from app.services.sql_validator import validate_sql
+
+
+def get_llm_provider():
+    if settings.llm_provider == "groq":
+        return groq_service
+    return ollama_service
 
 
 class RealEstateService:
@@ -8,7 +15,8 @@ class RealEstateService:
         self.repository = respository
 
     def seach(self, natural_query: str):
-        sql = generate_sql(natural_query)
+        provider = get_llm_provider()
+        sql = provider.generate_sql(natural_query)
 
         validated_sql = validate_sql(sql)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.9"
 dependencies = [
     "cryptography>=46.0.6",
     "fastapi[standard]>=0.128.8",
+    "groq>=0.5.0",
     "ollama>=0.6.1",
     "pydantic>=2.12.5",
     "pydantic-settings>=2.11.0",


### PR DESCRIPTION
## Summary
- Add Groq as alternative LLM provider (free tier)
- Keep Ollama for local development
- Configurable via `LLM_PROVIDER` env var
- Get free API key at https://console.groq.com

## Changes
- `groq_service.py` - new service using llama-3.1-70b-versatile
- `config.py` - add `groq_api_key` and `llm_provider` settings
- `real_estate_service.py` - dynamic provider selection
- `.env.example` - configuration example