### PR TITLE
fix(groq): replace decommissioned llama-3.1-70b-versatile with llama-3.3-70b-versatile

### DIFF
--- a/backend/app/services/groq_service.py
+++ b/backend/app/services/groq_service.py
@@ -5,7 +5,7 @@ from groq import Groq
 from app.core.config import settings
 from app.services.prompts import build_prompt
 
-MODEL_NAME = "llama-3.1-70b-versatile"
+MODEL_NAME = "llama-3.3-70b-versatile"
 
 DATABASE_ENGINE = "POSTGRESQL"
 


### PR DESCRIPTION
Closes #7

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Replaces decommissioned Groq model `llama-3.1-70b-versatile` with the official replacement `llama-3.3-70b-versatile`
- The old model returns HTTP 400 `model_decommissioned` errors since January 24, 2025
- New model offers same capabilities: 128K context, JSON mode, tool use, free tier

## Changes

| File | Change |
|------|--------|
| `backend/app/services/groq_service.py` | Updated `MODEL_NAME` constant to `llama-3.3-70b-versatile` |

## Test Plan

- [x] Manually tested: Groq API returns valid SQL with the new model
- [x] No shellcheck required (Python file, not shell scripts)
- [x] No behavior change — same model family, same parameters

## Contributor Checklist

- [x] Linked an approved issue (`#7`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers