### PR TITLE
fix(prompt): add json keyword and clarify JSON output format for Groq API

### DIFF
--- a/backend/app/services/prompts.py
+++ b/backend/app/services/prompts.py
@@ -40,10 +40,9 @@ STRICT RULES:
 8. Response MUST end with semicolon
 
 STRICT OUTPUT RULES:
-- DO NOT use markdown
-- DO NOT use ```sql
-- RETURN plain text only
-- START directly with SELECT
+- Return ONLY a valid JSON object with this exact structure: {"sql": "<your SELECT statement>"}
+- DO NOT include markdown, explanations, or any text outside the JSON
+- The SQL value must start with SELECT and end with a semicolon
 """
 
 ALLOWED_COLUMNS = [


### PR DESCRIPTION
Closes #9

## PR Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Groq's API requires the word "json" in the messages when using `response_format: json_object` — the prompt was missing it, causing 400 errors
- Fixed a contradiction: the prompt told the model to return plain SQL starting with SELECT, but the service parses `{"sql": "..."}` JSON
- Output rules now explicitly define the expected JSON structure

## Changes

| File | Change |
|------|--------|
| `backend/app/services/prompts.py` | Updated `STRICT OUTPUT RULES` to include "json" keyword and define the `{"sql": "..."}` response format |

## Test Plan

- [x] Manually tested: Groq API returns valid JSON with `{"sql": "..."}` structure
- [x] No shellcheck required (Python file)
- [x] Verified error no longer occurs

## Contributor Checklist

- [x] Linked an approved issue (`#9`)
- [x] Added exactly one `type:*` label (`type:bug`)
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers